### PR TITLE
Add npm badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # addons-moz-compare
 
-[![CircleCI](https://circleci.com/gh/mozilla/addons-moz-compare.svg?style=svg)](https://circleci.com/gh/mozilla/addons-moz-compare)
+[![CircleCI](https://circleci.com/gh/mozilla/addons-moz-compare.svg?style=svg)](https://circleci.com/gh/mozilla/addons-moz-compare) [![npm version](https://badge.fury.io/js/addons-moz-compare.svg)](https://www.npmjs.com/package/addons-moz-compare)
 
 A JavaScript library to compare Mozilla add-on versions that follow the [Manifest Version Format](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version/format).
 


### PR DESCRIPTION
We have that on other projects and I find it useful to quickly identify the current-ish version without having to go to npmjs.org