### PR TITLE
Use Node 14 and 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,13 @@ references:
     working_directory: ~/addons-moz-compare
     docker:
       # This is the NodeJS version we run in production.
-      - image: circleci/node:12-browsers
+      - image: circleci/node:14-browsers
 
   defaults-next: &defaults-next
     working_directory: ~/addons-moz-compare
     docker:
       # This is the next NodeJS version we will support.
-      - image: circleci/node:14-browsers
+      - image: circleci/node:16-browsers
 
   restore_build_cache: &restore_build_cache
     restore_cache:


### PR DESCRIPTION
Fixes #16 

---

We are migrating all our projects to use Node 14 by default, and we want to set Node 16 as the next version.

