### PR TITLE
Update browser-tools ORB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ references:
         - ~/.cache/yarn
 
 orbs:
-  browser-tools: circleci/browser-tools@1.1.0
+  browser-tools: circleci/browser-tools@1.4.1
 
 jobs:
   test:


### PR DESCRIPTION
This is needed to fix build issues, e.g. in #33. See also: https://github.com/CircleCI-Public/browser-tools-orb/issues/62